### PR TITLE
fix error reporting when failed to connect to telehealth module

### DIFF
--- a/telehealth/controllers/C_TSalud_Vc.php
+++ b/telehealth/controllers/C_TSalud_Vc.php
@@ -1109,9 +1109,10 @@ function requestAPI($data, $method = '', $files = false)
         // echo "<br>Calling API...";
         $result = curl_exec($curl);
         if (!$result) {
-            $error = "API $curl - Connection Failure";
-            logVc('0', 'Error', "$error");
-            die($error);
+            $error = curl_error($curl);
+            $url = curl_getinfo($curl, CURLINFO_EFFECTIVE_URL);
+            logVc('0', 'Error', "API Connection Failure to $url: $error");
+            die("API Connection Failure to $url: $error");
         }
     } catch (Exception $e) {
         // echo $e->getMessage();


### PR DESCRIPTION
currently, failure to connect to telehealth module result in this being thrown
```
openemr-1  | 2024/08/27 17:06:49 [error] 13#13: *3 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Object of class CurlHandle could not be converted to string in /var/www/html/telehealth/controllers/C_TSalud_Vc.php:1112
openemr-1  | Stack trace:
openemr-1  | #0 /var/www/html/telehealth/controllers/C_TSalud_Vc.php(539): requestAPI(Array, 47)
openemr-1  | #1 /var/www/html/interface/main/calendar/add_edit_event.php(756): createVc(17)
```
This patch improves the diagnostic to the way it is presumably intended to work.